### PR TITLE
[KHAF-56] 플래너 작업 현황

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -56,7 +56,7 @@ function App() {
 
       <Routes>
         <Route
-          path="/planner/*"
+          path="/planner/:planNo?"
           element={<LoginRouting element={<PlannerFrm />} />}
         />
 

--- a/src/components/planner/MarkerWithOverlay.js
+++ b/src/components/planner/MarkerWithOverlay.js
@@ -17,7 +17,7 @@ const MarkerWithOverlay = (props) => {
     <>
       <MapMarker
         position={p.placeLatLng}
-        onClick={() => setOpenOverlay(idx)}
+        onClick={() => setOpenOverlay(p.placeId)}
         image={
           isPlanned
             ? {
@@ -34,8 +34,8 @@ const MarkerWithOverlay = (props) => {
           </div>
         </CustomOverlayMap>
       )}
-      {openOverlay === idx && (
-        <CustomOverlayMap clickable={true} position={p.placeLatLng}>
+      {openOverlay === p.placeId && (
+        <CustomOverlayMap clickable={true} position={p.placeLatLng} zIndex={2}>
           <div className="overlay-wrap">
             <div className="overlay-info">
               <div className="overlay-title">
@@ -79,11 +79,19 @@ const MarkerWithOverlay = (props) => {
                     </div>
                     <div className="place-btn">
                       {isPlanned ? (
-                        <button onClick={deletePlan}>삭제</button>
+                        <button
+                          onClick={() => {
+                            setOpenOverlay(null);
+                            deletePlan(p.order);
+                          }}
+                        >
+                          삭제
+                        </button>
                       ) : (
                         <button
                           onClick={() => {
-                            setOpenPlanningModal(idx);
+                            // setOpenOverlay(null);
+                            setOpenPlanningModal(p.placeId);
                           }}
                         >
                           추가

--- a/src/components/planner/MarkerWithOverlay.js
+++ b/src/components/planner/MarkerWithOverlay.js
@@ -1,0 +1,104 @@
+import { Close } from "@mui/icons-material";
+import { CustomOverlayMap, MapMarker } from "react-kakao-maps-sdk";
+import StarRating from "../utils/StarRating";
+
+const MarkerWithOverlay = (props) => {
+  const p = props.place;
+  const idx = props.idx;
+  const [openOverlay, setOpenOverlay] = [
+    props.openOverlay,
+    props.setOpenOverlay,
+  ];
+  const setOpenPlanningModal = props.setOpenPlanningModal;
+  const isPlanned = props.isPlanned;
+  const deletePlan = props.deletePlan;
+
+  return (
+    <>
+      <MapMarker
+        position={p.placeLatLng}
+        onClick={() => setOpenOverlay(idx)}
+        image={
+          isPlanned
+            ? {
+                src: "https://t1.daumcdn.net/localimg/localimages/07/mapapidoc/markerStar.png",
+                size: { width: 24, height: 35 },
+              }
+            : undefined
+        }
+      />
+      {isPlanned && (
+        <CustomOverlayMap position={p.placeLatLng} yAnchor={1}>
+          <div className="numbered-marker">
+            <div className="marker-circle">{p.order + 1}</div>
+          </div>
+        </CustomOverlayMap>
+      )}
+      {openOverlay === idx && (
+        <CustomOverlayMap clickable={true} position={p.placeLatLng}>
+          <div className="overlay-wrap">
+            <div className="overlay-info">
+              <div className="overlay-title">
+                <div className="overlay-title-name">
+                  {p.placeTitle}
+                  <span className="overlay-class">{p.placeType}</span>
+                </div>
+                <div
+                  className="overlay-close"
+                  onClick={() => setOpenOverlay(null)}
+                  title="닫기"
+                >
+                  <Close />
+                </div>
+              </div>
+              <div className="overlay-body">
+                <div className="overlay-img">
+                  <img
+                    src={p.placeThumb}
+                    width="85"
+                    height="80"
+                    alt={p.placeTitle}
+                  />
+                </div>
+                <div className="overlay-desc">
+                  <div className="overlay-addr">{p.placeAddr}</div>
+                  <div className="overlay-rating">
+                    <StarRating rating={p.placeRating} />
+                    <span>
+                      ( {p.placeReview > 999 ? "999+" : p.placeReview} )
+                    </span>
+                  </div>
+                  <div className="overlay-below">
+                    <div
+                      className="overlay-link"
+                      // href="#"
+                      // target="_blank"
+                      // rel="noreferrer"
+                    >
+                      상세보기
+                    </div>
+                    <div className="place-btn">
+                      {isPlanned ? (
+                        <button onClick={deletePlan}>삭제</button>
+                      ) : (
+                        <button
+                          onClick={() => {
+                            setOpenPlanningModal(idx);
+                          }}
+                        >
+                          추가
+                        </button>
+                      )}
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </CustomOverlayMap>
+      )}
+    </>
+  );
+};
+
+export default MarkerWithOverlay;

--- a/src/components/planner/planner.css
+++ b/src/components/planner/planner.css
@@ -206,8 +206,16 @@
   object-fit: cover;
   margin-right: 10px;
 }
+.planned-date {
+  text-align: center;
+  font-size: 14px;
+  color: var(--gray4);
+}
 .planner-del-btn > svg {
   cursor: pointer;
+}
+.planned-item .place-title {
+  font-size: 14px;
 }
 
 /* 여행지에 추가하기 모달 */
@@ -238,17 +246,36 @@
   display: flex;
   justify-content: center;
 }
+.planning-info .place-item {
+  width: 300px;
+}
+.planning-info .planned-img {
+  width: 70px;
+  height: 70px;
+}
 .date-input {
   margin-bottom: 20px;
 }
 
-/* 범위 슬라이더 */
+/* 슬라이더 및 버튼 */
 .radius-slider {
   position: absolute;
   top: 10px;
   right: 10px;
   z-index: 1;
   background-color: var(--gray7);
+}
+.save-plan-btn {
+  position: absolute;
+  top: 60px;
+  right: 50px;
+  z-index: 1;
+}
+.save-plan-btn button {
+  width: 75px;
+  height: 40px;
+  border-radius: 10px;
+  font-size: 18px;
 }
 
 /* 카카오 맵 */

--- a/src/components/planner/planner.css
+++ b/src/components/planner/planner.css
@@ -35,10 +35,14 @@
 .filter-pressed {
   background-color: var(--gray6);
   font-weight: bold;
+  position: relative;
 }
 .filter-reset-btn {
   cursor: pointer;
   position: absolute;
+  right: 0;
+  width: 16px !important;
+  height: 16px !important;
 }
 .filter-reset-btn:hover > :first-child {
   color: tomato;
@@ -367,4 +371,22 @@
   color: #5085bb;
   cursor: pointer;
   font-size: 13px;
+}
+
+.arrow-marker {
+  font-size: 20px;
+  display: inline-block;
+  transform-origin: center;
+}
+.numbered-marker {
+  background-color: tomato;
+  border-radius: 50%;
+  width: 15px;
+  height: 15px;
+}
+.marker-circle {
+  line-height: 15px;
+  font-size: 15px;
+  color: white;
+  text-align: center;
 }


### PR DESCRIPTION
 ## ✨ 작업 내용 
- /planner 라우팅 방식을 "/planner/:planNo?"로 다시 변경함
- 받아온 장소 데이터를 지도 상 마커로 표시하는 기능을 독립 컴포넌트로 분리함
- 장소 필터링 옵션을 추가함
- 이제 플래너에 추가된 여행지가 지도 상에 별도 마커로 표시되며, 방문 순서와 직선경로가 표현됨
- 플래너 '저장' 버튼 및 테이블 insert 기능 작업 중

 ## 🐞 완료한 하위 이슈 및 진행상황
 KHAF-59 지도 구현중(91%)
 KHAF-62 장소 사이드뷰 구현중(99%)
 KHAF-96 플래너 사이드뷰 구현중(80%)
 KHAF-98 플래너 사용 가이드 미구현
 KHAF-99 여행 상세페이지 모달 미구현
 KHAF-100 리뷰 모달 미구현